### PR TITLE
Refactor how vm is downloaded

### DIFF
--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -1,5 +1,5 @@
 # Prepare a base image to use docker cache during build
-FROM debian:bullseye-slim as base
+FROM debian:11-slim as base
 LABEL maintainer="serpi90@gmail.com"
 WORKDIR /opt/pharo
 # hadolint ignore=DL3008

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -1,5 +1,5 @@
 # Prepare a base image to use docker cache during build
-FROM debian:10-slim as base
+FROM debian:bullseye-slim as base
 LABEL maintainer="serpi90@gmail.com"
 WORKDIR /opt/pharo
 # hadolint ignore=DL3008
@@ -13,7 +13,7 @@ RUN set -eu; \
   apt-get clean; \
   useradd --uid 7431 --gid 100 --home-dir /opt/pharo --no-create-home --no-user-group pharo; \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
-  printf '#!/bin/bash\n/opt/pharo/vm/pharo "$@"' > /opt/pharo/pharo; \
+  printf '#!/bin/bash\n/opt/pharo/vm/pharo --headless "$@"' > /opt/pharo/pharo; \
   ln -s /opt/pharo/pharo /usr/local/bin/pharo; \
   chmod a+x /usr/local/bin/pharo; \
   chown 7431:100 /opt/pharo -R; \
@@ -22,14 +22,16 @@ RUN set -eu; \
 
 # Download pharo vm and remove unwanted stuff
 FROM alpine:3.12 as download-vm
-WORKDIR /opt/pharo
-ADD http://files.pharo.org/get-files/90/pharo64-linux-headless-latest.zip ./
-RUN mkdir vm && unzip -d vm pharo64-linux-headless-latest.zip
+RUN apk add unzip bash curl
+WORKDIR /tmp/pharo
+RUN curl https://get.pharo.org/vm90 | bash
+
 
 
 # Copy vm into base image
 FROM base as vm
-COPY --from=download-vm --chown=pharo:users /opt/pharo/vm /opt/pharo/vm
+COPY --from=download-vm --chown=pharo:users /tmp/pharo/pharo-vm /opt/pharo/vm
+RUN rm -rf /tmp/pharo
 USER pharo
 
 


### PR DESCRIPTION
 - Updated code which downloaded the VM to use zeroconf instead of a specific URL

- Allows Dockerfile to run on any cpu that can be detected by the zeroconf script

- Specifically fixes an issue I had running Pharo in Docker on an M1 Mac (and linux vm's of type aarch64)